### PR TITLE
add inotifywait 自动监控 to #4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,10 @@ FROM lsiobase/ubuntu:bionic
 # set label
 LABEL maintainer="NG6"
 
-ENV TZ=Asia/Shanghai TASK=1d PUID=1026 PGID=100
+ENV TZ=Asia/Shanghai PUID=1026 PGID=100
 
 # install subfinder
-RUN apt -y update && apt -y install python3 python3-pip unrar \
+RUN apt -y update && apt -y install python3 python3-pip unrar inotify-tools \
 &&  pip3 install --upgrade pip \
 &&  pip install subfinder \
 &&  echo "**** cleanup ****" \

--- a/root/etc/services.d/subfinder/run
+++ b/root/etc/services.d/subfinder/run
@@ -1,9 +1,12 @@
-#!/usr/bin/with-contenv bash
+#!/bin/bash
 
-# 启动定时任务,默认一小时执行一次
-# 启动subfinder查找字幕
-s6-setuidgid abc \
-	subfinder /media \
-	-c /config/subfinder.json
-echo ==============本轮搜索已结束，下次遍历为${TASK}后==============
-sleep $TASK
+inotifywait -mrq --timefmt '%y/%m/%d %H:%M' --format '%T %w%f %e' --event delete,modify,create,attrib /media | while read date time file event; do
+	case $event in
+	CREATE)
+		echo $event'-'$file'-'$date'-'$time
+		if [ "${file##*.}"x = "mkv"x ] || [ "${file##*.}"x = "mp4"x ] || [ "${file##*.}"x = "iso"x ]; then
+			/usr/local/bin/subfinder $file -c /config/subfinder.json --debug
+		fi
+		;;
+	esac
+done


### PR DESCRIPTION
使用了Linux 系统级别的方法 `inotifywait` 监听目录文件变动 [ref](https://www.ibm.com/developerworks/cn/linux/l-ubuntu-inotify/index.html)

![image](https://user-images.githubusercontent.com/3975345/79364570-1c8e9500-7f7c-11ea-8ac0-c8dc0a378645.png)

todo: 监听特定后缀ext文件配置，目前为mkv mp4 iso